### PR TITLE
Increase max column width

### DIFF
--- a/lua/weapons/junk_cannon.lua
+++ b/lua/weapons/junk_cannon.lua
@@ -183,8 +183,7 @@ function SWEP:ThrowProp(force, model, mass, colour)
 end
 
 function SWEP:LoadProp(ent)
-	self.Hopper[#self.Hopper + 1] =
-		{ ent:GetModel(), ent:GetPhysicsObject():GetMass(), ent:GetColor() }
+	self.Hopper[#self.Hopper + 1] = { ent:GetModel(), ent:GetPhysicsObject():GetMass(), ent:GetColor() }
 	ent:Remove()
 
 	net.Start("JunkCannon.RegisterHopperSize")

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,4 +1,4 @@
-column_width = 80
+column_width = 120
 line_endings = "Unix"
 indent_type = "Tabs"
 indent_width = 4


### PR DESCRIPTION
## Changes

- Increases the column width to 120 in `stylua.toml`

## Impact

120 is generally a better default for modern monitors (80 is a legacy from old terminals)

## Helpful Links

[Discord](https://discord.tasevers.com)
