### PR TITLE
Global Author Object Proposal

### DIFF
--- a/lua/autorun/tas_weapons_init.lua
+++ b/lua/autorun/tas_weapons_init.lua
@@ -1,3 +1,4 @@
 TASWeapons = {
 	Category = "TAS Weapons",
+	Authors = { "Derpius", "Kilo" }, --STEAM_0:0:547731733 Derpius, STEAM_0:0:84051936 Kilo
 }

--- a/lua/autorun/tas_weapons_init.lua
+++ b/lua/autorun/tas_weapons_init.lua
@@ -1,4 +1,4 @@
 TASWeapons = {
 	Category = "TAS Weapons",
-	Authors = { "Derpius", "Kilo" }, --STEAM_0:0:547731733 Derpius, STEAM_0:0:84051936 Kilo
+	Authors = { Derpius = "Derpius", Kilo = "Kilo" }, --STEAM_0:0:547731733 Derpius, STEAM_0:0:84051936 Kilo
 }

--- a/lua/weapons/junk_cannon.lua
+++ b/lua/weapons/junk_cannon.lua
@@ -19,7 +19,7 @@ end
 
 SWEP.PrintName = "Junk Cannon"
 SWEP.Category = TASWeapons.Category
-SWEP.Author = TASWeapons.Authors[1]
+SWEP.Author = TASWeapons.Authors.Derpius
 SWEP.Instructions = [[Right click to add small props to your prop hopper
 Left click to fire the oldest one you picked up
 

--- a/lua/weapons/junk_cannon.lua
+++ b/lua/weapons/junk_cannon.lua
@@ -19,7 +19,7 @@ end
 
 SWEP.PrintName = "Junk Cannon"
 SWEP.Category = TASWeapons.Category
-SWEP.Author = "Derpius"
+SWEP.Author = TASWeapons.Authors[1]
 SWEP.Instructions = [[Right click to add small props to your prop hopper
 Left click to fire the oldest one you picked up
 

--- a/lua/weapons/kilos_combat_toolgun.lua
+++ b/lua/weapons/kilos_combat_toolgun.lua
@@ -1,5 +1,5 @@
 SWEP.PrintName = "Kilo's Combat Tool Gun"
-SWEP.Author = "Kilo"
+SWEP.Author = TASWeapons.Authors[2]
 SWEP.Purpose = "For when circumstances exceed that of the regular tool gun."
 SWEP.Category = TASWeapons.Category
 

--- a/lua/weapons/kilos_combat_toolgun.lua
+++ b/lua/weapons/kilos_combat_toolgun.lua
@@ -1,5 +1,5 @@
 SWEP.PrintName = "Kilo's Combat Tool Gun"
-SWEP.Author = TASWeapons.Authors[2]
+SWEP.Author = TASWeapons.Authors.Kilo
 SWEP.Purpose = "For when circumstances exceed that of the regular tool gun."
 SWEP.Category = TASWeapons.Category
 


### PR DESCRIPTION
Resolves #7

# Global Author Object
Proposal for #7, assigns each author an ID (~just an integer index~ an internal name) that can be used to reference the author, to move to a slightly more data normalised form.

## Benefits
 - See #7
## ~Why use `TASWeapons.Authors[1]` rather than `TASWeapons.Authors.Derpius`?~
 - ~By using a table with properties based on names the benefits of data normalisation are lost and the global author object becomes redundant.~