### PR TITLE
11 - Fix CI when PR is raised from a fork

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,16 @@
+name: Deploy to production
+
+on:
+  push:
+    branches: master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    environment: production
+    concurrency: production
+
+    steps:
+      - name: Post to webhook
+        run: curl --fail-with-body -X POST ${{ secrets.DEPLOYER_WEBHOOK }}/${{ github.event.repository.name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,12 @@ on:
     branches: master
 
 jobs:
+  lint:
+    uses: "./.github/workflows/lint.yml"
+
   deploy:
     runs-on: ubuntu-latest
+    needs: lint
 
     environment: production
     concurrency: production

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: JohnnyMorganz/stylua-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           version: latest
           args: --check lua/
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint and format
 
-on: [push, pull_request]
+on: workflow_call
 
 jobs:
   lint:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     env:
-      GLUAFIXER_VERSION: 1.23.0
+      GLUAFIXER_VERSION: 1.26.0
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lua CI
+name: Lint and format
 
 on: [push, pull_request]
 
@@ -24,15 +24,3 @@ jobs:
 
       - name: Run GLuaFixer
         run: ./glualint --output-format github --config .glualint.json lint lua
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [lint]
-    if: ${{ format('refs/heads/{0}', github.event.repository.default_branch) == github.ref }}
-
-    environment: production
-    concurrency: production
-
-    steps:
-      - name: Post to webhook
-        run: curl --fail-with-body -X POST ${{ secrets.DEPLOYER_WEBHOOK }}/${{ github.event.repository.name }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,9 @@
+name: Pull request created or updated
+
+on: pull_request
+
+jobs:
+  lint:
+    uses: "./.github/workflows/lint.yml"
+    # Only run on forks to avoid duplicating the "push" workflow
+    if: ${{ github.event.pull_request.base.repo.fork }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,9 @@
+name: Push to non-release branch
+
+on:
+  push:
+    branches-ignore: master
+
+jobs:
+  lint:
+    uses: "./.github/workflows/lint.yml"


### PR DESCRIPTION
## Issue

Resolves #11

## Changes

- Splits linting job out into a reusable workflow
- Creates separate deploy, push and pull request workflows
- Replaces `secrets.GITHUB_TOKEN` with `github.token` in lint workflow, which should hopefully resolve the issues with PRs from forks incorrectly passing
- Reduces duplicate workflow runs for PRs from within the repo

## Impact

Should have a significant impact on developer experience

## Testing

n/a

## Helpful Links

[Discord](https://discord.tasevers.com)
